### PR TITLE
Fix editor and result overflow

### DIFF
--- a/client/less/editor.less
+++ b/client/less/editor.less
@@ -48,7 +48,7 @@
     position: relative;
     float: left;
     width: 50%;
-    height: 100%;
+    height: calc(100% - @topbar-height);
     border-right:1px solid #999;
 }
 
@@ -56,7 +56,7 @@
     position: relative;
     float: left;
     width: 50%;
-    height: 100%;
+    height: calc(100% - @topbar-height);
     background-color:#fff;
     background-image:
       -moz-linear-gradient(45deg, #ddd 25%, transparent 25%),


### PR DESCRIPTION
Bottom scrollbar in editor not visible and results has invalid size due to Editor's height (and Result's height) equals 100% of body,  but  Navbar offsets them on 33px to bottom.